### PR TITLE
webhook: allow triggering webhooks through api

### DIFF
--- a/src/webhook_launcher/app/serializers.py
+++ b/src/webhook_launcher/app/serializers.py
@@ -9,14 +9,28 @@ class LastSeenRevisionSerializer(serializers.ModelSerializer):
     class Meta:
         model = LastSeenRevision
 
+class BuildServiceField(serializers.WritableField):
+    """
+    Handle references to a BuildService object
+    Outputs namespace
+    Takes a namespace as a key
+    """
+    def to_native(self, obj):
+        return BuildServiceSerializer().to_native(obj)
+
+    def from_native(self, data):
+        try:
+            obs = BuildService.objects.get(namespace=data)
+        except BuildService.DoesNotExist as e:
+            obs = None
+        return obs
+
 class WebHookMappingSerializer(serializers.ModelSerializer):
     lsr = LastSeenRevisionSerializer(many=False, read_only=True)
-    revision = serializers.CharField(source="lsr.revision", write_only=True)
-    obs = BuildServiceSerializer(many=False, read_only=True)
-    obs_id = serializers.IntegerField(source="obs.pk", write_only=True)
+    revision = serializers.CharField(source="lsr.revision", write_only=True, required=False)
+    obs = BuildServiceField()
     user = serializers.RelatedField(many=False, read_only=True)
 
     class Meta:
         model = WebHookMapping
         depth = 2
-


### PR DESCRIPTION
Overwrite update() and partial_update() functions in WebHookMappingViewSet.
update maps to HTTP PUT and partial_update to HTTP PATCH.

To trigger webhook do HTTP PUT  to /api/webhookmappings/{pk}/

BuildServiceField taken form David's work.