### PR TITLE
Use rpm/precheckin.sh to generate spec files.

### DIFF
--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -198,12 +198,12 @@ sanitise_params () {
 
 generate_spec_files () {
 
-    [[ -f "rpm/precheckin.sh" ]] || return 0
+    [[ -f "rpm/genspecs.sh" ]] || return 0
 
-    echo "Generating spec files from rpm/precheckin.sh"
+    echo "Generating spec files from rpm/genspecs.sh"
     pushd rpm >/dev/null
     rm -f *.spec
-    sh precheckin.sh || error "Could not generate .spec files with precheckin.sh"
+    sh genspecs.sh || error "Could not generate .spec files with genspecs.sh"
     popd >/dev/null
 
 }

--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -196,6 +196,18 @@ sanitise_params () {
 
 }
 
+generate_spec_files () {
+
+    [[ -f "rpm/precheckin.sh" ]] || return 0
+
+    echo "Generating spec files from rpm/precheckin.sh"
+    pushd rpm >/dev/null
+    rm -f *.spec
+    sh precheckin.sh || error "Could not generate .spec files with precheckin.sh"
+    popd >/dev/null
+
+}
+
 find_spec_file () {
 
   [[ -d "$1" ]] || error "no packaging in this git clone"
@@ -1091,6 +1103,7 @@ main () {
     return
   fi
   pushd "$CLONE_NAME" >/dev/null
+  generate_spec_files
   # check for default manifest file
   if test -f default.xml; then
     run_android_repo_service


### PR DESCRIPTION
Follows the specification as laid out by @thp in issue #5, basically: if rpm/precheckin.sh exists, assume we can delete rpm/*.spec and generate them by running `sh precheckin.sh` in the rpm dir.
Precheckin.sh is not run for dumb mode, but otherwise unconditionally (android, rpm and debian case)

There are no transitional features at the moment, so
running it against https://github.com/mer-packages/gdb.git fails because because of bashsims in its rpm/precheckin.sh (and then because the template is gdb.spec).    

Question: Do we want to deal with these possible failure modes, or should the burden be on the other packages to update their packaging practices?
