### PR TITLE
Store cached git repos by URL, not submodule directory name

### DIFF
--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -674,8 +674,7 @@ git_ls_files () {
 
 cache_prefetch () {
 
-  NAME=$1
-  URL=$2
+  URL=$1
 
   if [ x"$CACHE_DIR" = "x" ]; then
       return
@@ -685,6 +684,7 @@ cache_prefetch () {
       error "$CACHE_DIR doesn't exist ..."
   fi
 
+  NAME="$(basename $URL)"
   SERVER_SUBDIR="$(dirname $URL)"
   [[ "$SERVER_SUBDIR" = "." ]] && SERVER_SUBDIR=$URL
   
@@ -723,7 +723,7 @@ handle_submodules() {
       path=$(git config -f .gitmodules --get submodule.$name.path | cut -d= -f2)
     
       URL=$url
-      cache_prefetch $name $URL
+      cache_prefetch $URL
     
       REFERENCE=""
       [ -d "$URL" ] && REFERENCE="--reference $URL"
@@ -787,7 +787,7 @@ clone () {
 
   echo "Handling $CLONE_NAME"
   URL=$MYURL
-  cache_prefetch $CLONE_NAME $URL
+  cache_prefetch $URL
   MYURL=$URL
 
   if [ -d $CLONE_NAME ]; then


### PR DESCRIPTION
Remove name parameter from cache_prefetch, as the local directory name
may clash with other repos (e.g. 'upstream'). Instead just use the
remaining last path component of the URL.
