### PR TITLE
[tar_git] Fix changelog uniq filtering for different line endings

### DIFF
--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -484,9 +484,11 @@ get_tagmsg () {
 }
 
 dash_trim () {
-  # and workaround for github breaking the subject line with ... automatically
-  # in pull requests
-  sed -e 's/^/- /' -e '/^\s*$/d' -e 's/JB#[0-9]\{1,\}\.\.\.$//'
+  # * Workaround for github breaking the subject line with ... automatically
+  #   in pull requests
+  # * Fix uniq filtering by normalizing the \r\n line endings used by gitlab
+  #   in merge commit messages
+  sed -e 's/^/- /' -e '/^\s*$/d' -e 's/JB#[0-9]\{1,\}\.\.\.$//' -e 's/\r//'
 }
 
 grep_entry () {


### PR DESCRIPTION
Tested on mer tracker repo, and the diff on the generated changes file before and after the fix looks correct.
