### PR TITLE
Avoid infinite loop on submodule with . in their name

### DIFF
--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -721,8 +721,11 @@ handle_submodules() {
   local submod url url_host url_proto url_path baseurl path URL REFERENCE
   baseurl=${1%/}
   for submod in $(git config -f .gitmodules -l | grep -P 'submodule\..*\.url' | xargs); do
-    url=$(echo $submod | cut -d= -f2)
-    name=$(echo $submod | cut -d= -f1 | cut -d. -f2)
+    # FIXME: using characters thay may appear in submodule names
+    # (e.g. "=" and ".") as separators is asking for trouble
+    url=${submod##*.url=}
+    submod_prefix=${submod%.url=*}
+    name=${submod_prefix#submodule.}
     # Handle relative URLs and optionally configure local submodules
     case "$url" in
     ../*)


### PR DESCRIPTION
Fixes #44 

There are probably many more cases where we should carefully check the separator being used.