### PR TITLE
Use local time for file timestamps in tar_git

### DIFF
--- a/src/service/tar_git
+++ b/src/service/tar_git
@@ -992,7 +992,7 @@ rpm_pkg () {
      echo -n $VERSHA > .tarball-version
   fi
   
-  commitdate=$(git log -1 --date=short --pretty=format:%cd)
+  commitdate=$(git log -1 --date=short-local --pretty=format:%cd)
   git_ls_files | tar --mtime "$commitdate" --null --no-recursion -c --transform "s#^#$PACKAGE_NAME-$VERSHA/#S" -T - | $COMPRESS_COMMAND > $MYOUTDIR/$PACKAGE_NAME-$VERSHA.$COMPRESS_EXT
 
   set_spec_version


### PR DESCRIPTION
If commit has timestamp in timezone that is ahead of local time, with
plain --date=short the file modification time can end up in the future.
Using the short-local option makes sure it is converted to local date
and tar will set the modification time correctly.