### PR TITLE
Don't throw errors in the process definition.

### DIFF
--- a/src/webhook_launcher/processes/VCSCOMMIT_BUILD
+++ b/src/webhook_launcher/processes/VCSCOMMIT_BUILD
@@ -24,7 +24,7 @@ Ruote.process_definition 'wh_trigger_build' do
     set :f => 'log_channel', :value => '#mer-boss'
     set :f => 'highlight', :value => ''
     # Any error will get notified by this flanked suprocess
-    do_log_error :flank => true
+    on_error "do_log_error"
 
     # Mer projects are not created by this process
     # This should be conditional though
@@ -49,51 +49,42 @@ Ruote.process_definition 'wh_trigger_build' do
   end
 
   define 'do_log' do
-    sequence do
-      echo 'process ${wfid}: ${v:msg}'
-      notify_irc :msg => 'process ${wfid} ${v:msg}',
-                 :irc_channel => '#mer-boss'
-    end
+    echo 'process ${wfid}: ${v:msg}'
+    notify_irc :msg => 'process ${wfid} ${v:msg}',
+               :irc_channel => '#mer-boss'
   end
 
   define 'do_wait_for_src' do
-    sequence do
-      do_log :msg => 'Waiting for ${project}/${package} source'
-      set 'v:timeout_step' => "getting source state"
-      repeat :timeout => '4h', :on_timeout => 'do_log_timeout' do
-        wait '2m'
-        get_src_state :project => '${project}', :package => '$package'
-        _break :if => '${f:service_state}' != "running"
-      end
-      _if '"${service_state}" != "succeeded"' do
-        error "Failed to get source for ${project}/${package}"
-      end
+    do_log :msg => 'Waiting for ${project}/${package} source'
+    set 'v:timeout_step' => "getting source state"
+    repeat :timeout => '4h', :on_timeout => 'do_log_timeout' do
+      wait '2m'
+      get_src_state :project => '${project}', :package => '$package'
+      _break :if => '${f:service_state}' != "running"
+    end
+    _if '"${service_state}" != "succeeded"' do
+      error "Failed to get source for ${project}/${package}"
     end
   end
 
   define 'do_wait_for_build' do
-    sequence do
-      do_log :msg => 'Waiting for ${project} to build'
-      set 'v:timeout_step' => "wating for repo publish"
-      repeat :timeout => '48h', :on_timeout => 'do_log_timeout' do
-        wait '2m'
-        is_repo_published :project => '${project}', :package => '$package'
-        _break :if => '${f:__result__}'
-      end
+    do_log :msg => 'Waiting for ${project} to build'
+    set 'v:timeout_step' => "wating for repo publish"
+    repeat :timeout => '48h', :on_timeout => 'do_log_timeout' do
+      wait '2m'
+      is_repo_published :project => '${project}', :package => '$package'
+      _break :if => '${f:__result__}'
     end
   end
 
   define 'do_log_error' do
-    cursor do
-      listen :to => :errors
-      echo 'process ${wfid}: SR#${ev.id} ERROR'
-      notify_irc :if => '"${log_channel}" != ""',
-                 :msg => '${highlight} process ${wfid} ERROR',
-                 :irc_channel => '${log_channel}'
-      #notify :template => '${template.error}', :mail_to => "$f:admin_emails",
-      #       :subject => '[${pname}] ${wfid} SR#${req.id} ERROR'
-      rewind
-    end
+    echo 'process ${wfid}: SR#${ev.id} ERROR'
+    notify_irc :if => '"${log_channel}" != ""',
+               :msg => '${highlight} process ${wfid} ERROR ${__error__.message}',
+               :irc_channel => '${log_channel}'
+    #notify :template => '${template.error}', :mail_to => "$f:admin_emails",
+    #       :subject => '[${pname}] ${wfid} SR#${req.id} ERROR'
+    terminate
   end
 
   define 'do_log_timeout' do

--- a/src/webhook_launcher/processes/VCSCOMMIT_BUILD
+++ b/src/webhook_launcher/processes/VCSCOMMIT_BUILD
@@ -29,7 +29,7 @@ Ruote.process_definition 'wh_trigger_build' do
     # Mer projects are not created by this process
     # This should be conditional though
     create_project
-    trigger_service
+    trigger_service :on_error => "do_service_error"
     # We wait for the source before checking the build results as
     # is_repo_published can fail if the service is still running
     do_wait_for_src
@@ -40,6 +40,12 @@ Ruote.process_definition 'wh_trigger_build' do
         auto_promote
       end
     end
+  end
+
+  define 'do_service_error' do
+    notify_irc :msg => 'Error triggering service in ${project}/${package}. Check cibot has access.',
+               :irc_channel => '#mer-boss'
+    terminate
   end
 
   define 'do_log' do
@@ -53,7 +59,8 @@ Ruote.process_definition 'wh_trigger_build' do
   define 'do_wait_for_src' do
     sequence do
       do_log :msg => 'Waiting for ${project}/${package} source'
-      repeat :timeout => '4h', :on_timeout => 'error' do
+      set 'v:timeout_step' => "getting source state"
+      repeat :timeout => '4h', :on_timeout => 'do_log_timeout' do
         wait '2m'
         get_src_state :project => '${project}', :package => '$package'
         _break :if => '${f:service_state}' != "running"
@@ -67,7 +74,8 @@ Ruote.process_definition 'wh_trigger_build' do
   define 'do_wait_for_build' do
     sequence do
       do_log :msg => 'Waiting for ${project} to build'
-      repeat :timeout => '48h', :on_timeout => 'error' do
+      set 'v:timeout_step' => "wating for repo publish"
+      repeat :timeout => '48h', :on_timeout => 'do_log_timeout' do
         wait '2m'
         is_repo_published :project => '${project}', :package => '$package'
         _break :if => '${f:__result__}'
@@ -86,6 +94,14 @@ Ruote.process_definition 'wh_trigger_build' do
       #       :subject => '[${pname}] ${wfid} SR#${req.id} ERROR'
       rewind
     end
+  end
+
+  define 'do_log_timeout' do
+    echo 'process ${wfid}: SR#${ev.id} TIMEOUT'
+    notify_irc :if => '"${log_channel}" != ""',
+               :msg => '${highlight} TIMEOUT for ${project}/${package} ${v:timeout_step}',
+               :irc_channel => '${log_channel}'
+    terminate
   end
 
 end

--- a/src/webhook_launcher/processes/VCSCOMMIT_BUILD
+++ b/src/webhook_launcher/processes/VCSCOMMIT_BUILD
@@ -43,15 +43,17 @@ Ruote.process_definition 'wh_trigger_build' do
   end
 
   define 'do_service_error' do
-    notify_irc :msg => 'Error triggering service in ${project}/${package}. Check cibot has access.',
-               :irc_channel => '#mer-boss'
+    notify_irc :if => '"${log_channel}" != ""',
+               :msg => 'Error triggering service in ${project}/${package}. Check cibot has access.',
+               :irc_channel => '${log_channel}'
     terminate
   end
 
   define 'do_log' do
     echo 'process ${wfid}: ${v:msg}'
-    notify_irc :msg => 'process ${wfid} ${v:msg}',
-               :irc_channel => '#mer-boss'
+    notify_irc :if => '"${log_channel}" != ""',
+               :msg => 'process ${wfid} ${v:msg}',
+               :irc_channel => '${log_channel}'
   end
 
   define 'do_wait_for_src' do

--- a/src/webhook_launcher/processes/VCSCOMMIT_QUEUE
+++ b/src/webhook_launcher/processes/VCSCOMMIT_QUEUE
@@ -24,23 +24,20 @@ Ruote.process_definition 'wh_handle_git_event' do
     set :f => 'highlight', :value => ' '
 
     # Any error will get notified by this flanked suprocess
-    do_log_error :flank => true
+    on_error "do_log_error"
 
     handle_webhook
     relay_webhook
   end
 
   define 'do_log_error' do
-    cursor do
-      listen :to => :errors
-      echo 'process ${wfid}: SR#${ev.id} ERROR'
-      notify_irc :if => '"${log_channel}" != ""',
-                 :msg => '${highlight} process ${wfid} ERROR',
-                 :irc_channel => '${log_channel}'
-      #notify :template => '${template.error}', :mail_to => "$f:admin_emails",
-      #       :subject => '[${pname}] ${wfid} SR#${req.id} ERROR'
-      rewind
-    end
+    echo 'process ${wfid}: SR#${ev.id} ERROR'
+    notify_irc :if => '"${log_channel}" != ""',
+               :msg => '${highlight} process ${wfid} ERROR',
+               :irc_channel => '${log_channel}'
+    #notify :template => '${template.error}', :mail_to => "$f:admin_emails",
+    #       :subject => '[${pname}] ${wfid} SR#${req.id} ERROR'
+    terminate
   end
 
 end


### PR DESCRIPTION
Report what went wrong in the timeouts and the rather more common
error of triggering a service

Signed-off-by: David Greaves <david.greaves@jolla.com>