### PR TITLE
Constraint support.

### DIFF
--- a/rpm/boss-launcher-webhook.spec
+++ b/rpm/boss-launcher-webhook.spec
@@ -54,7 +54,7 @@ This package provides the service to update webhooks from OBS. It ensures that o
 
 %package -n boss-participant-trigger_service
 Group: Applications/Engineering
-Requires: python-boss-skynet >= 0.6.0, boss-standard-workflow-common, python-lxml, python-buildservice >= 0.5.3
+Requires: python-boss-skynet >= 0.6.0, boss-standard-workflow-common, python-lxml, python-yaml, python-buildservice >= 0.5.3
 Summary: BOSS participant to handle webhooks
 %description -n boss-participant-trigger_service
 This package provides the participant that handles creating and/or triggering  _service files in OBS, in response to webhook triggers


### PR DESCRIPTION
The file /etc/skynet/trigger_service_constraints.yaml can contain disk
or ram constraints on a per package basis.

Patterns can be used to support multiple packages too (for HA)

eg to give qtbase package a minimum of 6Gb of disk:
qtbase:
  disk: 6

Signed-off-by: David Greaves <david.greaves@jolla.com>