### PR TITLE
Message is utf-8 so encode before printing

### DIFF
--- a/src/webhook_launcher/app/models.py
+++ b/src/webhook_launcher/app/models.py
@@ -540,7 +540,7 @@ class WebHookMapping(models.Model):
 
         fields = self.to_fields()
         fields['msg'] = message
-        print message
+        print message.encode('utf-8')
         launch_notify(fields)
 
     def to_fields(self):


### PR DESCRIPTION
This prevents errors in boss due to UnicodeEncodeError

Signed-off-by: David Greaves <david.greaves@jolla.com>